### PR TITLE
Handle missing VITE_GOOGLE_API_KEY at runtime and surface errors in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,36 @@
-# 🚀 React + Vite Starter Template
+# Gemini Clone (React + Vite)
 
-This project provides a clean and minimal setup to get started with **React** using **Vite**. It includes hot module replacement (HMR) and essential ESLint rules for code quality.
+A simple Gemini-style chat UI built with React and Vite.
 
-## 📦 Features
+## Local development
 
-- ⚡ **Vite** for fast builds and development
-- ⚛️ **React** with HMR support
-- ✅ Pre-configured **ESLint**
-- 🎯 Optional plugin support with Babel or SWC
-
-## 🔌 Available Plugins
-
-Choose one of the official Vite plugins for React:
-
-- [`@vitejs/plugin-react`](https://github.com/vitejs/vite-plugin-react) – Uses **Babel** for Fast Refresh
-- [`@vitejs/plugin-react-swc`](https://github.com/vitejs/vite-plugin-react-swc) – Uses **SWC** for blazing-fast builds
-
-## 🧪 ESLint Configuration
-
-The current setup includes a basic ESLint configuration. For production-grade apps, we recommend:
-
-- Adding **TypeScript**
-- Enabling **type-aware** linting rules
-
-👉 You can explore the official [Vite + React + TypeScript template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) to get started.
-
-## 🛠️ Get Started
+1. Install dependencies:
 
 ```bash
 npm install
+```
+
+2. Create a `.env` file in the project root:
+
+```bash
+VITE_GOOGLE_API_KEY=your_google_ai_api_key
+```
+
+3. Start the app:
+
+```bash
 npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Deployment notes
+
+This app requires `VITE_GOOGLE_API_KEY` to be present at build/runtime (depending on host).
+If the key is missing, sending a prompt will fail with an explicit error message.
+
+For static hosts (Netlify, Vercel, GitHub Pages, etc.), set the environment variable in the platform settings before deploying.

--- a/src/Context/context.jsx
+++ b/src/Context/context.jsx
@@ -23,7 +23,7 @@ export const ContextProvider = ({ children }) => {
       const response = await runChat(prompt); // Gemini API Call
       setResultData(response);
     } catch (error) {
-      setResultData("❌ Failed to fetch response. Please try again.");
+      setResultData(`❌ ${error.message || "Failed to fetch response. Please try again."}`);
     }
 
     setLoading(false);

--- a/src/config/gemini.js
+++ b/src/config/gemini.js
@@ -5,15 +5,20 @@ import {
 } from "@google/generative-ai";
 
 const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY;
-console.log("Loaded API Key:", API_KEY);
 
-if (!API_KEY) {
-  throw new Error("API key is not defined in environment variables.");
+function getClient() {
+  if (!API_KEY) {
+    throw new Error(
+      "Missing VITE_GOOGLE_API_KEY. Add it to your environment before sending prompts."
+    );
+  }
+
+  return new GoogleGenerativeAI(API_KEY);
 }
 
-const genAI = new GoogleGenerativeAI(API_KEY);
-
 async function runChat(prompt) {
+  const genAI = getClient();
+
   // Primary model
   let model = genAI.getGenerativeModel({ model: "gemini-1.5-pro" });
 
@@ -57,9 +62,9 @@ async function runChat(prompt) {
   } catch (error) {
     console.error("Error with chat API (pro):", error);
 
-    // 👉 If it's a quota error (429), fallback to gemini-1.5-flash
+    // If it's a quota error (429), fallback to gemini-1.5-flash
     if (error.message.includes("429")) {
-      console.log("⚡ Falling back to gemini-1.5-flash due to quota limits...");
+      console.log("Falling back to gemini-1.5-flash due to quota limits...");
 
       model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
       chat = model.startChat({


### PR DESCRIPTION
### Motivation
- The app crashed when the environment variable `VITE_GOOGLE_API_KEY` was missing because validation ran at module-import time, which breaks deployed static builds. 
- Users and deployers need a clear, actionable error when prompts fail due to missing credentials instead of a silent or generic failure.

### Description
- Move API key validation into a `getClient()` helper so `VITE_GOOGLE_API_KEY` is checked at request time inside `src/config/gemini.js` rather than on module load. 
- Remove client-side API key logging and return a `GoogleGenerativeAI` instance from `getClient()`; `runChat` now calls `getClient()` before starting a chat. 
- Update the chat context in `src/Context/context.jsx` to surface the actual error message by setting `resultData` to ``❌ ${error.message ||

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db223b61b483239b0f5cd8934de15f)